### PR TITLE
fixes to work for msal single-tenancy

### DIFF
--- a/src/msal/index.js
+++ b/src/msal/index.js
@@ -11,11 +11,12 @@ export default class AuthService {
     this.graphUrl = config.graphendpoint
     this.applicationConfig = {
       clientID: config.clientid,
+      authority: config.authority,
       graphScopes: config.graphscopes
     }
     this.app = new Msal.UserAgentApplication(
       this.applicationConfig.clientID,
-      '',
+      this.applicationConfig.authority,
       () => {
         // callback for login redirect
       },


### PR DESCRIPTION
Authority was given in the `./src/config/index.js` file but not carried through too `./src/msal/index.js`. Fixing allows multi-tenancy to work. 